### PR TITLE
Adding additional features to CdsServiceClient over WebAPI

### DIFF
--- a/src/Build.Common.StandardAndLegacy.props
+++ b/src/Build.Common.StandardAndLegacy.props
@@ -1,0 +1,14 @@
+<Project>
+  <PropertyGroup Condition="'$(TargetFrameworks)' == ''">
+    <TargetFrameworks Condition="'$(OutputType)' == 'Exe'">netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OutputType)' != 'Exe'">netstandard2.0</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Features>IOperation</Features>
+  </PropertyGroup>
+
+  <Import Project=".\Build.Shared.props" />
+
+</Project>

--- a/src/Build.Common.core.props
+++ b/src/Build.Common.core.props
@@ -9,6 +9,12 @@
     <Features>IOperation</Features>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Compile Remove="obj\**" />
+    <EmbeddedResource Remove="obj\**" />
+    <None Remove="obj\**" />
+  </ItemGroup>
+
   <Import Project=".\Build.Shared.props" />
 
 </Project>

--- a/src/Build.Shared.props
+++ b/src/Build.Shared.props
@@ -1,0 +1,88 @@
+<Project>
+  <!-- msbuild properties shared for dotnetCore and .NET classic projects: -->
+  <PropertyGroup>
+    <PackageVersion_AppInsights>2.9.1</PackageVersion_AppInsights>
+    <PackageVersion_Adal>3.19.8</PackageVersion_Adal>
+    <PackageVersion_CdsSdk>4.5.2071</PackageVersion_CdsSdk>
+    <PackageVersion_CDSServerNuget>4.5.3122</PackageVersion_CDSServerNuget>
+    <PackageVersion_Newtonsoft>10.0.3</PackageVersion_Newtonsoft>
+    <PackageVersion_RestClientRuntime>2.3.20</PackageVersion_RestClientRuntime>
+    <PackageVersion_XrmSdk>9.0.2.25</PackageVersion_XrmSdk>
+    <!-- Test: -->
+    <PackageVersion_Moq>4.13.1</PackageVersion_Moq>
+    <PackageVersion_XUnit>2.4.1</PackageVersion_XUnit>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- this property must be re-defined in individual .csprojs or a .props file per component area -->
+    <ComponentAreaName Condition="'$(ComponentAreaName)' == ''">FORGOT-To-Set-ComponentAreaName</ComponentAreaName>    
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <!-- These variables define the object and binary roots, respectively. -->
+    <RepoRoot>$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine($(MSBuildThisFileDirectory), ".."))))</RepoRoot>
+    <OutputRootDir Condition=" '$(OutputRootDir)' == '' ">$(RepoRoot)\bin\$(Configuration)\$(ComponentAreaName)\$(TargetFramework)</OutputRootDir>
+    <OutputRootDir>$(OutputRootDir.TrimEnd({'\\'}))</OutputRootDir>
+    <!-- These variables are the ones that the standard MSBuild targets recognize. -->
+    <OutDir Condition=" '$(OutDir)' =='' ">$([System.IO.Path]::Combine($(OutputRootDir), $(RelativeOutputPath)))</OutDir>
+    <!-- OutDir requires a trailing slash to prevent MSB8004 warning -->
+    <OutDir>$(OutDir.TrimEnd("\\"))\</OutDir>
+    <!-- Ensures OutputPath always matches OutDir -->
+    <OutputPath>$(OutDir)</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(SignAssembly)' == 'true'">
+    <AssemblyOriginatorKeyFile>$(RepoRoot)\build\crmKey\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>true</DelaySign>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <Optimize>false</Optimize>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DefineConstants>TRACE</DefineConstants>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <Optimize>false</Optimize>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <DefineConstants>TRACE</DefineConstants>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'CRMINTERNAL|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <DefineConstants>DEBUG;TRACE;CRMINTERNAL</DefineConstants>
+    <Optimize>false</Optimize>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Enable_Telemetry)' == 'true' " >
+    <DefineConstants>$(DefineConstants);PROD_CUSTOMER_TELEMETRY</DefineConstants>
+  </PropertyGroup>
+</Project>

--- a/src/GeneralTools/CDSClient/Client/Microsoft.Powerplatform.Cds.Client.csproj
+++ b/src/GeneralTools/CDSClient/Client/Microsoft.Powerplatform.Cds.Client.csproj
@@ -38,4 +38,8 @@
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.7.0" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net48'">
+    <Reference Include="System.Web" />
+  </ItemGroup>
+
 </Project>

--- a/src/nuspecs/Microsoft.Dynamics.Sdk.Messages.ReleaseNotes.txt
+++ b/src/nuspecs/Microsoft.Dynamics.Sdk.Messages.ReleaseNotes.txt
@@ -8,6 +8,9 @@ Notice:
         https://docs.microsoft.com/en-us/dotnet/api/microsoft.crm.sdk.messages?view=dynamics-general-ce-9
 
 ++CURRENTRELEASEID++
+    No updates here. 
+
+0.2.17-Alpha:
     No Updates here. 
 
 0.2.16-Alpha:

--- a/src/nuspecs/Microsoft.Powerplatform.Cds.Client.Dynamics.ReleaseNotes.txt
+++ b/src/nuspecs/Microsoft.Powerplatform.Cds.Client.Dynamics.ReleaseNotes.txt
@@ -5,6 +5,9 @@ Notice:
     We have not stabilized on NameSpace or Class names with this package as of yet and things will change as we move though the preview.
 
 ++CURRENTRELEASEID++
+    No updates here. 
+
+0.2.17-Alpha:
 Added IntelliSense Doc Support
 Added support for bypassing custom Plug-in Execution during SDK Operation.  
     This is a special use capability that requires a specialized permission in the CDS infrastructure to use. 

--- a/src/nuspecs/Microsoft.Powerplatform.Cds.Client.ReleaseNotes.txt
+++ b/src/nuspecs/Microsoft.Powerplatform.Cds.Client.ReleaseNotes.txt
@@ -9,6 +9,10 @@ Notice:
     Note: that only OAuth, Certificate, ClientSecret Authentication types are supported at this time. 
 
 ++CURRENTRELEASEID++
+Added support for Alternate key use on entity references as part of Create Update Delete Operations running over the webAPI. 
+Added concurrency support to Create Update Delete Operations running over the webAPI. 
+
+0.2.17-Alpha:
 ***BREAKING CHANGE***
 Renamed Exception CdsConnectionException to CdsClientConnectionException.  No other change to the Exception
 ***


### PR DESCRIPTION
Added support for Alternate key use on entity references as part of Create Update Delete Operations running over the webAPI.
Added concurrency support to Create Update Delete Operations running over the webAPI.

resolves #50 
resolves #53 